### PR TITLE
All x3ml to allow builds by jitpack

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk11


### PR DESCRIPTION
https://jitpack.io/ is a nice service that can build Java projects from the github and make them available as maven dependencies. You can quickly build any branch/tag/commit hash and use it as a dependency immediately.

By default it uses Java 8 so one need to have a small config file in the project root to use Java 11.

E.g see build from my fork with this change - https://jitpack.io/#aindlq/x3ml/jitpack-740cc13d5a-1