### PR TITLE
Add custom x3ml:uuid xpath function.

### DIFF
--- a/src/main/java/gr/forth/ics/isl/x3ml/X3MLEngine.java
+++ b/src/main/java/gr/forth/ics/isl/x3ml/X3MLEngine.java
@@ -52,6 +52,7 @@ import static gr.forth.ics.isl.x3ml.engine.X3ML.Helper.x3mlStream;
 import static gr.forth.ics.isl.x3ml.engine.X3ML.MappingNamespace;
 import static gr.forth.ics.isl.x3ml.engine.X3ML.RootElement;
 import gr.forth.ics.isl.x3ml.engine.X3ML.TargetInfo;
+import gr.forth.ics.isl.x3ml.engine.xpath.Namespace;
 import gr.forth.Labels;
 import gr.forth.Utils;
 import gr.forth.ics.isl.x3ml.engine.ModelOutput;
@@ -311,6 +312,7 @@ public class X3MLEngine {
         ((XPathContext) namespaceContext).addNamespace(Labels.XML, Labels.XML_NAMESPACE);
         prefixes.add(Labels.XML);
         ((XPathContext) namespaceContext).addNamespace(Labels.SKOS, Labels.SKOS_NAMESPACE);
+        ((XPathContext) namespaceContext).addNamespace(Namespace.CUSTOM_FUNCTIONS_PREFIX, Namespace.CUSTOM_FUNCTIONS_NAMESPACE);
         prefixes.add(Labels.SKOS);
     }
 

--- a/src/main/java/gr/forth/ics/isl/x3ml/engine/XPathInput.java
+++ b/src/main/java/gr/forth/ics/isl/x3ml/engine/XPathInput.java
@@ -39,6 +39,10 @@ import static gr.forth.ics.isl.x3ml.engine.X3ML.SourceType;
 import gr.forth.IterableNodeList;
 import gr.forth.Labels;
 import gr.forth.Utils;
+import gr.forth.ics.isl.x3ml.engine.X3ML.GeneratorElement;
+import gr.forth.ics.isl.x3ml.engine.X3ML.SourceType;
+import gr.forth.ics.isl.x3ml.engine.xpath.UUIDFunction_v3;
+
 import java.io.StringWriter;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
@@ -49,6 +53,7 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import static gr.forth.ics.isl.x3ml.X3MLEngine.exception;
 import lombok.extern.log4j.Log4j2;
+import net.sf.saxon.Configuration;
 import net.sf.saxon.dom.DOMNodeList;
 
 import static org.joox.JOOX.$;
@@ -63,9 +68,8 @@ import static org.joox.JOOX.$;
  * @author Yannis Marketakis &lt;marketak@ics.forth.gr&gt;
  */
 @Log4j2
-public class XPathInput {
-
-    private final XPathFactory pathFactory = new net.sf.saxon.xpath.XPathFactoryImpl();
+public class XPathInput {    
+    private final XPathFactory pathFactory;
     private final NamespaceContext namespaceContext;
     private final String languageFromMapping;
     private final Node rootNode;
@@ -78,6 +82,12 @@ public class XPathInput {
         this.rootNode = rootNode;
         this.namespaceContext = namespaceContext;
         this.languageFromMapping = languageFromMapping;
+
+        // register custom xpath functions
+        net.sf.saxon.xpath.XPathFactoryImpl pathFactoryImpl = new net.sf.saxon.xpath.XPathFactoryImpl();
+        Configuration config = pathFactoryImpl.getConfiguration();
+        config.registerExtensionFunction(new UUIDFunction_v3());
+        this.pathFactory = pathFactoryImpl;
     }
 
     public X3ML.ArgValue evaluateArgument(Node node, int index, GeneratorElement generatorElement, String argName, SourceType defaultType, boolean mergeMultipleValues) {

--- a/src/main/java/gr/forth/ics/isl/x3ml/engine/xpath/Namespace.java
+++ b/src/main/java/gr/forth/ics/isl/x3ml/engine/xpath/Namespace.java
@@ -1,0 +1,6 @@
+package gr.forth.ics.isl.x3ml.engine.xpath;
+
+public class Namespace {
+    public static String CUSTOM_FUNCTIONS_PREFIX = "x3ml";
+    public static String CUSTOM_FUNCTIONS_NAMESPACE = "http://gr.forth.ics.isl/x3ml/custom-functions";
+}

--- a/src/main/java/gr/forth/ics/isl/x3ml/engine/xpath/UUIDFunction_v3.java
+++ b/src/main/java/gr/forth/ics/isl/x3ml/engine/xpath/UUIDFunction_v3.java
@@ -1,0 +1,59 @@
+/*==============================================================================
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+==============================================================================*/
+package gr.forth.ics.isl.x3ml.engine.xpath;
+
+import java.util.UUID;
+
+import net.sf.saxon.expr.XPathContext;
+import net.sf.saxon.lib.ExtensionFunctionCall;
+import net.sf.saxon.lib.ExtensionFunctionDefinition;
+import net.sf.saxon.om.Sequence;
+import net.sf.saxon.om.StructuredQName;
+import net.sf.saxon.trans.XPathException;
+import net.sf.saxon.value.SequenceType;
+import net.sf.saxon.value.StringValue;
+
+public class UUIDFunction_v3 extends ExtensionFunctionDefinition {
+    private static String FUNCTION_NAME = "uuid";
+
+    @Override
+    public StructuredQName getFunctionQName() {
+        return new StructuredQName(Namespace.CUSTOM_FUNCTIONS_PREFIX, Namespace.CUSTOM_FUNCTIONS_NAMESPACE, FUNCTION_NAME);
+    }
+
+    @Override
+    public SequenceType[] getArgumentTypes() {
+        return new SequenceType[]{SequenceType.SINGLE_STRING};
+    }
+
+    @Override
+    public SequenceType getResultType(SequenceType[] suppliedArgumentTypes) {
+        return SequenceType.SINGLE_STRING;
+    }
+
+    @Override
+    public ExtensionFunctionCall makeCallExpression() {
+        return new ExtensionFunctionCall() {
+            @Override
+            public Sequence call(XPathContext context, Sequence[] arguments) throws XPathException {
+                String input = arguments[0].head().getStringValue();
+                String uuid = UUID.nameUUIDFromBytes(input.getBytes()).toString().toUpperCase();
+                return StringValue.makeStringValue(uuid);
+            }
+        };
+    }
+}

--- a/src/test/java/eu/delving/x3ml/TestCustomXpathFunctions.java
+++ b/src/test/java/eu/delving/x3ml/TestCustomXpathFunctions.java
@@ -1,0 +1,44 @@
+/*==============================================================================
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+==============================================================================*/
+package eu.delving.x3ml;
+
+import static eu.delving.x3ml.AllTests.*;
+import static org.junit.Assert.assertTrue;
+
+
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Test;
+
+import gr.forth.ics.isl.x3ml.X3MLEngine;
+
+public class TestCustomXpathFunctions {
+
+    @Test
+    public void testUUIDv3Function() {
+        X3MLEngine engine = engine("/custom_functions/01-coin-simple.x3ml");
+        X3MLEngine.Output output = engine.execute(document("/custom_functions/01-coin-input.xml"), policy("/custom_functions/00-generator-policy.xml"));
+        String[] mappingResult = output.toStringArray();
+        System.out.println(StringUtils.join(mappingResult, "\n"));
+        String[] expectedResult = xmlToNTriples("/custom_functions/01-coin-simple-rdf.xml");
+        List<String> diff = compareNTriples(expectedResult, mappingResult);
+        assertTrue("\n" + StringUtils.join(diff, "\n") + "\n", errorFree(diff));
+    }
+}

--- a/src/test/resources/custom_functions/00-generator-policy.xml
+++ b/src/test/resources/custom_functions/00-generator-policy.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<generator_policy>
+    
+    <generator name="SimpleLabel">
+        <pattern>{label}</pattern>
+    </generator>
+    <generator name="LocalTermURI" prefix="adw">
+        <pattern>{hierarchy}/{term}</pattern>
+    </generator>
+	<generator name="GermanDateTime">
+        <custom generatorClass="gr.forth.GermanDate">
+            <set-arg name="bound" type="constant"/>
+            <set-arg name="text"/>
+        </custom>
+    </generator>
+
+    <generator name="SimpleTerm" prefix="prefix">
+        <pattern>{term}</pattern>
+    </generator>
+
+	<generator name="URIorUUID">
+        <custom generatorClass="gr.forth.URIorUUID">
+            <set-arg name="text"/>
+        </custom>
+    </generator>
+
+</generator_policy>

--- a/src/test/resources/custom_functions/01-coin-input.xml
+++ b/src/test/resources/custom_functions/01-coin-input.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dataroot>
+    <COIN>
+        <ID>627</ID>
+        <COUNTRY_ID>1</COUNTRY_ID>
+        <FIND_SPOT_ID>242</FIND_SPOT_ID>
+        <FIND_MANNER_ID>2</FIND_MANNER_ID>
+        <FIND_DATE>1980er Jahre</FIND_DATE>
+        <AUTHORITY_ID>566</AUTHORITY_ID>
+        <ISSUER_ID>536</ISSUER_ID>
+        <DENOMINATION>30</DENOMINATION>
+        <MINT_ID>244</MINT_ID>
+		<MINT_MARK>mint mark</MINT_MARK>
+        <OFFICINA>99</OFFICINA>
+        <DATE_CA>0</DATE_CA>
+        <DATE_FROM>-116</DATE_FROM>
+        <DATE_TO>-115</DATE_TO>
+        <DAT_VAL>1088408850</DAT_VAL>
+        <WEIGHT>3.46</WEIGHT>
+        <DIE_AXE>4</DIE_AXE>
+        <STATUS_ID>1</STATUS_ID>
+        <RV_LEG>CN.DOMI</RV_LEG>
+        <RV_PIC>Iuppiter in Quadriga n. r. ..</RV_PIC>
+        <ARCH_INFO>-</ARCH_INFO>
+        <PH_NAME>000627</PH_NAME>
+        <DAT_TXT>116 - 115 v. Chr.</DAT_TXT>
+    </COIN>
+	<!--<COIN>
+        <ID>1627</ID>
+        <COUNTRY_ID>2</COUNTRY_ID>
+        <FIND_SPOT_ID>242</FIND_SPOT_ID>
+        <FIND_MANNER_ID>2</FIND_MANNER_ID>
+        <FIND_DATE>1980er Jahre</FIND_DATE>
+        <AUTHORITY_ID>566</AUTHORITY_ID>
+        <ISSUER_ID>536</ISSUER_ID>
+        <DENOMINATION>30</DENOMINATION>
+        <MINT_ID>244</MINT_ID>
+		<MINT_MARK>mint mark</MINT_MARK>
+        <OFFICINA>99</OFFICINA>
+        <DATE_CA>0</DATE_CA>
+        <DATE_FROM>1900-1910</DATE_FROM>
+        <DATE_TO>1950-1955</DATE_TO>
+        <DAT_VAL>1088408850</DAT_VAL>
+        <WEIGHT>3.46</WEIGHT>
+        <DIE_AXE>4</DIE_AXE>
+        <STATUS_ID>1</STATUS_ID>
+        <RV_LEG>CN.DOMI</RV_LEG>
+        <RV_PIC>Iuppiter in Quadriga n. r. ..</RV_PIC>
+        <ARCH_INFO>-</ARCH_INFO>
+        <PH_NAME>000627</PH_NAME>
+        <DAT_TXT>116 - 115 v. Chr.</DAT_TXT>
+    </COIN>-->
+    <COUNTRY>
+        <COUNTRY_ID>1</COUNTRY_ID>
+        <COUNTRY_NAME>Österreich</COUNTRY_NAME>
+        <COUNTRY_NAME_EN>Austria</COUNTRY_NAME_EN>
+    </COUNTRY>
+	<COUNTRY>
+        <COUNTRY_ID>2</COUNTRY_ID>
+        <COUNTRY_NAME>Deutchland</COUNTRY_NAME>
+        <COUNTRY_NAME_EN>Germany</COUNTRY_NAME_EN>
+    </COUNTRY>
+    <FIND_SPOT>
+        <FS_ID>242</FS_ID>
+        <FS_NAME>Mautern</FS_NAME>
+        <FS_ORDER_KEY>10</FS_ORDER_KEY>
+        <FS_S_ORDER_KEY>000020_000030_000090_000170_000010</FS_S_ORDER_KEY>
+        <EXCLUDE>0</EXCLUDE>
+    </FIND_SPOT>
+    <FIND_SPOT>
+        <FS_ID>666</FS_ID>
+        <FS_NAME>To Be Avoided</FS_NAME>
+        <FS_ORDER_KEY>10</FS_ORDER_KEY>
+        <FS_S_ORDER_KEY>9494949494949</FS_S_ORDER_KEY>
+        <EXCLUDE>0</EXCLUDE>
+    </FIND_SPOT>
+    <FIND_MANNER>
+        <FM_ID>2</FM_ID>
+        <FM_NAME>Streufund</FM_NAME>
+        <FM_NAME_EN>stray-find</FM_NAME_EN>
+    </FIND_MANNER>
+    <AUTHORITY>
+        <AUTH_ID>566</AUTH_ID>
+        <AUTH_NAME>REPUBLIK</AUTH_NAME>
+        <AUTH_NAME_EN>ROME / REPUBLIC</AUTH_NAME_EN>
+        <AUTH_ORDER_KEY>30</AUTH_ORDER_KEY>
+        <AUTH_S_ORDER_KEY>000030</AUTH_S_ORDER_KEY>
+    </AUTHORITY>
+    <ISSUER>
+        <PR_ID>536</PR_ID>
+        <PR_NAME>CN.DOMI, Q. CVRTI, M. SILA</PR_NAME>
+        <PR_NAME_EN>CN. DOMI, Q. CVRTI, M. SILA</PR_NAME_EN>
+        <PR_ORDER_KEY>940</PR_ORDER_KEY>
+        <PR_S_ORDER_KEY>000030_000940</PR_S_ORDER_KEY>
+        <EXCLUDE>0</EXCLUDE>
+    </ISSUER>
+    <DENOMINATION>
+        <DEN_ID>30</DEN_ID>
+        <DEN_NAME>D</DEN_NAME>
+        <DEN_NAME_EN>D</DEN_NAME_EN>
+        <DEN_ORDER_KEY>140</DEN_ORDER_KEY>
+        <DEN_S_ORDER_KEY>000010_000020_000140</DEN_S_ORDER_KEY>
+        <DEN_METAL>2</DEN_METAL>
+        <EXCLUDE>0</EXCLUDE>
+    </DENOMINATION>
+    <MINT>
+        <MINT_ID>244</MINT_ID>
+        <MINT_NAME>Rom (Rep.)</MINT_NAME>
+        <MINT_NAME_EN>Rome</MINT_NAME_EN>
+        <MINT_ORDER_KEY>10</MINT_ORDER_KEY>
+        <MINT_S_ORDER_KEY>000030_000010</MINT_S_ORDER_KEY>
+        <EXCLUDE>0</EXCLUDE>
+    </MINT>
+</dataroot>

--- a/src/test/resources/custom_functions/01-coin-simple-rdf.xml
+++ b/src/test/resources/custom_functions/01-coin-simple-rdf.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+         xmlns:crm="http://www.cidoc-crm.org/cidoc-crm/"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+    <crm:E22_Man-Made_Object rdf:about="uuid:A">
+        <crm:P1_is_identified_by>
+            <crm:E41_Appellation rdf:about="http://example.org/185C29DC-2432-3934-AE37-7CFDA20E414C">
+                <rdfs:label>627</rdfs:label>
+            </crm:E41_Appellation>
+        </crm:P1_is_identified_by>
+    </crm:E22_Man-Made_Object>
+</rdf:RDF>

--- a/src/test/resources/custom_functions/01-coin-simple.x3ml
+++ b/src/test/resources/custom_functions/01-coin-simple.x3ml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x3ml version="1.0" source_type="xpath">
+    <namespaces>
+        <namespace prefix="crm" uri="http://www.cidoc-crm.org/cidoc-crm/"/>
+        <namespace prefix="rdf" uri="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+        <namespace prefix="rdfs" uri="http://www.w3.org/2000/01/rdf-schema#"/>
+        <namespace prefix="prefix" uri="http://example.org/"/>
+    </namespaces>
+    <mappings>
+        <mapping>
+            <domain>
+                <source_node>//COIN</source_node>
+                <target_node>
+                    <entity>
+                        <type>crm:E22_Man-Made_Object</type>
+                        <instance_generator name="UUID"/>
+                    </entity>
+                </target_node>
+            </domain>
+            <link>
+                <path>
+                    <source_relation><relation>ID</relation></source_relation>
+                    <target_relation>
+                        <relationship>crm:P1_is_identified_by</relationship>
+                    </target_relation>
+                </path>
+                <range>
+                    <source_node>ID</source_node>
+                    <target_node>
+                        <entity>
+                            <type>crm:E41_Appellation</type>
+                            <instance_generator name="SimpleTerm">
+								<arg name="term" type="xpath">x3ml:uuid(text())</arg>
+							</instance_generator>
+                            <label_generator name="Literal">
+                                <arg name="text">text()</arg>
+                                <arg name="language"/>
+                            </label_generator>
+                        </entity>
+                    </target_node>
+                </range>
+            </link>
+        </mapping>
+    </mappings>
+</x3ml>


### PR DESCRIPTION
In MIDAS mappings for PHAROS we have a situation where if some ID element is defined then we want to use it's value as part of URI or otherwise generate UUID based on number of elements. 

Without this change the whole mapping needs to be duplicated with different generators based on exist/not exist of that element.

With this change we can simply do something like:

```
(if (a2606) then a2606 else x3ml:uuid(lower-case(concat(a2700, a2690, a2664))))
```

and if a2606 is defined we get `work/ID` if it doesn't then we get `work/UUID`.